### PR TITLE
Fix for local usage with OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your_openai_api_key_here
+PORT=3001

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Clareza Emocional
+
+Simple React application with a small Express proxy to call the OpenAI API. The proxy avoids CORS issues when running the app in the browser.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Copy `.env.example` to `.env` and fill in your OpenAI API key.
+
+   ```bash
+   cp .env.example .env
+   # edit .env and set OPENAI_API_KEY
+   ```
+
+3. Start the backend server:
+   ```bash
+   npm run server
+   ```
+   The server runs on port defined in `.env` (default `3001`).
+
+4. In another terminal start the React app:
+   ```bash
+   npm start
+   ```
+
+Then open `http://localhost:3000` in your browser.

--- a/package.json
+++ b/package.json
@@ -7,12 +7,17 @@
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "i18next": "^22.4.9",
-    "react-i18next": "^13.0.0"
+    "react-i18next": "^13.0.0",
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "node-fetch": "^2.6.7"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "server": "node server.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const fetch = require('node-fetch');
+const cors = require('cors');
+require('dotenv').config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.post('/api/completion', async (req, res) => {
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify(req.body),
+    });
+    const data = await response.json();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to contact OpenAI' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));

--- a/src/components/Affirmation.js
+++ b/src/components/Affirmation.js
@@ -9,12 +9,9 @@ export default function Affirmation() {
   const generate = async () => {
     setLoading(true);
     try {
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      const res = await fetch('/api/completion', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${process.env.REACT_APP_OPENAI_API_KEY}`,
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           model: 'gpt-3.5-turbo',
           messages: [

--- a/src/components/BotResponse.js
+++ b/src/components/BotResponse.js
@@ -9,12 +9,9 @@ export default function BotResponse({ note }) {
   useEffect(() => {
     const fetchResponse = async () => {
       try {
-        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        const res = await fetch('/api/completion', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${process.env.REACT_APP_OPENAI_API_KEY}`,
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             model: 'gpt-3.5-turbo',
             messages: [


### PR DESCRIPTION
## Summary
- add simple Express server for proxying OpenAI requests
- update frontend to use the new `/api/completion` endpoint
- include server dependencies in `package.json`
- provide `.env.example` and project instructions

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684186587c3c832dab535788ea8fe9da